### PR TITLE
Remove duplicate colon

### DIFF
--- a/clip.bash
+++ b/clip.bash
@@ -72,7 +72,7 @@ cmd_clip() {
     [[ $err -ne 0 ]] && die "$(cmd_clip_short_usage)"
 
     # Figure out if we use fzf or rofi
-    local prompt='Copy password into clipboard for 45 seconds:'
+    local prompt='Copy password into clipboard for 45 seconds'
     local fzf_cmd="fzf --print-query --prompt=\"$prompt\" | tail -n1"
     local rofi_cmd="rofi -dmenu -i -p \"$prompt\""
 


### PR DESCRIPTION
Hi! As you can see in the screenshot attachment, the colon at the end of the prompt is duplicated, rofi will add one itself. This PR removes it.
![2018-03-21-210450_4480x1440_scrot](https://user-images.githubusercontent.com/6866019/37734563-d75cff32-2d4b-11e8-81e5-43d226974f80.png)
