### PR TITLE
Attempt to automatically detect and use fzf or rofi

### DIFF
--- a/clip.bash
+++ b/clip.bash
@@ -69,6 +69,14 @@ cmd_clip() {
             --) shift; break ;;
     esac done
 
+    if [[ $fzf = 0 && $rofi = 0 ]]; then
+        if [[ -n $(command -v fzf) ]]; then
+            fzf=1
+        elif [[ -n $(command -v rofi) ]]; then
+            rofi=1
+        fi
+    fi
+
     [[ $err -ne 0 ]] && die "$(cmd_clip_short_usage)"
 
     # Figure out if we use fzf or rofi

--- a/clip.bash
+++ b/clip.bash
@@ -70,9 +70,9 @@ cmd_clip() {
     esac done
 
     if [[ $fzf = 0 && $rofi = 0 ]]; then
-        if [[ -n $(command -v fzf) ]]; then
+        if command_exists fzf; then
             fzf=1
-        elif [[ -n $(command -v rofi) ]]; then
+        elif command_exists rofi; then
             rofi=1
         fi
     fi
@@ -95,13 +95,7 @@ cmd_clip() {
         command_exists fzf || die "Could not find fzf in \$PATH"
         menu="$fzf_cmd"
     else
-        if command_exists rofi; then
-            menu="$rofi_cmd"
-        elif command_exists fzf; then
-            menu="$fzf_cmd"
-        else
-            die "Could not find either fzf or rofi in \$PATH"
-        fi
+        die "Could not find either fzf or rofi in \$PATH"
     fi
 
     cd "$PASSWORD_STORE_DIR" || exit 1


### PR DESCRIPTION
I personally found specifying -f cumbersome after a few iterations so I added
a crude auto-detect mechanism that tries to find these tools. The priority is
currently fzf > rofi but I'm willing to switch that around if you wish.
