### PR TITLE
exclude .extensions dir from search results

### DIFF
--- a/clip.bash
+++ b/clip.bash
@@ -109,7 +109,7 @@ cmd_clip() {
     cd "$PASSWORD_STORE_DIR" || exit 1
 
     # Select a passfile
-    passfile=$(find -L "$PASSWORD_STORE_DIR" -path '*/.git' -prune -o -iname '*.gpg' -printf '%P\n' |
+    passfile=$(find -L "$PASSWORD_STORE_DIR" -path '*/.git' -prune -o -path '*/.extensions' -prune -o -iname '*.gpg' -printf '%P\n' |
         sed -e 's/.gpg$//' |
         sort |
         eval "$menu")

--- a/clip.bash
+++ b/clip.bash
@@ -87,8 +87,8 @@ cmd_clip() {
     local rofi_cmd="rofi -dmenu -i -p \"$prompt\""
 
     if [ -n "$term" ]; then
-      fzf_cmd="$fzf_cmd -q\"$term\""
-      rofi_cmd="$rofi_cmd -filter \"$term\""
+        fzf_cmd="$fzf_cmd -q\"$term\""
+        rofi_cmd="$rofi_cmd -filter \"$term\""
     fi
     fzf_cmd="$fzf_cmd | tail -n1"
 
@@ -109,10 +109,10 @@ cmd_clip() {
     cd "$PASSWORD_STORE_DIR" || exit 1
 
     # Select a passfile
-    passfile=$(find -L "$PASSWORD_STORE_DIR" -path '*/.git' -prune -o -iname '*.gpg' -printf '%P\n' \
-        | sed -e 's/.gpg$//' \
-        | sort \
-        | eval "$menu" )
+    passfile=$(find -L "$PASSWORD_STORE_DIR" -path '*/.git' -prune -o -iname '*.gpg' -printf '%P\n' |
+        sed -e 's/.gpg$//' |
+        sort |
+        eval "$menu")
 
     if [ -z "$passfile" ]; then
         die 'No passfile selected.'

--- a/clip.bash
+++ b/clip.bash
@@ -83,7 +83,7 @@ cmd_clip() {
 
     # Figure out if we use fzf or rofi
     local prompt='Copy password into clipboard for 45 seconds'
-    local fzf_cmd="fzf --print-query --prompt=\"$prompt\""
+    local fzf_cmd="fzf --print-query --prompt=\"$prompt \""
     local rofi_cmd="rofi -dmenu -i -p \"$prompt\""
 
     if [ -n "$term" ]; then


### PR DESCRIPTION
Hi, i propose to follow the pass convention of excluding the ".extensions" dir that is somewhat reserved. All `find` commands do this in the main password-store.sh file: <https://git.zx2c4.com/password-store/tree/src/password-store.sh?h=b5e965a838bb68c1227caa2cdd874ba496f10149#n433>.

For me, i have submodules in .extensions that have .gpg files as tests that surface in pass-clip which is why i would like to see this change.

As a side quest, i added a space after the prompt in fzf, to separate the search term from the prompt:
![Screenshot 2024-12-03 at 16 26 47](https://github.com/user-attachments/assets/6191d2c0-540c-4418-bc77-b49a6c44ed3e)
